### PR TITLE
Reverse proxy and kodi/addons/webinterface support.

### DIFF
--- a/src/js/app.coffee
+++ b/src/js/app.coffee
@@ -11,6 +11,7 @@
     defaultPlayer: 'auto'
     ignoreArticle: true
     pollInterval: 10000
+    reverseProxy: false
     albumAtristsOnly: true
     searchIndexCacheExpiry: (24 * 60 * 60) # 1 day
     collectionCacheExpiry: (7 * 24 * 60 * 60) # 1 week (gets wiped on library update)
@@ -37,5 +38,3 @@
 $(document).ready =>
   @Kodi.start()
   $.material.init()
-
-

--- a/src/js/apps/command/kodi/_base/_base.js.coffee
+++ b/src/js/apps/command/kodi/_base/_base.js.coffee
@@ -5,7 +5,7 @@
     ajaxOptions: {}
 
     initialize: (options = {}) ->
-      $.jsonrpc.defaultUrl = config.get 'static', 'jsonRpcEndpoint'
+      $.jsonrpc.defaultUrl = helpers.url.baseKodiUrl "Base"
       @setOptions(options)
 
     setOptions: (options) ->
@@ -49,4 +49,3 @@
 
     onError: (commands, error) ->
       helpers.debug.rpcError commands, error
-

--- a/src/js/apps/images/images_app.js.coffee
+++ b/src/js/apps/images/images_app.js.coffee
@@ -24,7 +24,7 @@
       path
 
     parseRawPath: (rawPath) ->
-      path = 'image/' + encodeURIComponent(rawPath)
+      path = if config.get 'static', 'reverseProxy' then 'image/' + encodeURIComponent(rawPath) else '/image/' + encodeURIComponent(rawPath)
       path
 
     ## set background fanart, stting to 'none' removes fanart

--- a/src/js/apps/settings/show/local/local_controller.js.coffee
+++ b/src/js/apps/settings/show/local/local_controller.js.coffee
@@ -22,7 +22,7 @@
 
     getForm: ->
       options = {
-        form: @getSructure()
+        form: @getStructure()
         formState: @getState()
         config:
           attributes: {class: 'settings-form'}
@@ -32,30 +32,31 @@
       form = App.request "form:wrapper", options
       @layout.regionContent.show form
 
-    getSructure: ->
+    getStructure: ->
       [
         {
           title: 'General Options'
           id: 'general'
           children:[
-            {id: 'defaultPlayer', title: 'Default player', type: 'select', options: {auto: 'Auto', kodi: 'Kodi', local: 'Local'}, defaultValue: 'auto', description: 'What player to start with'}
+            {id: 'defaultPlayer', title: 'Default player', type: 'select', options: {auto: 'Auto', kodi: 'Kodi', local: 'Local'}, defaultValue: 'auto', description: t.gettext('What player to start with')}
           ]
         }
         {
           title: 'List options'
           id: 'list'
           children:[
-            {id: 'ignoreArticle', title: 'Ignore article', type: 'checkbox', defaultValue: true, description: 'Ignore terms such as "The" and "a" when sorting lists'}
-            {id: 'albumAtristsOnly', title: 'Album artists only', type: 'checkbox', defaultValue: true, description: 'When listing artists should we only see arttists with albums or all artists found. Warning: turning this off can impact performance with large libraries'}
+            {id: 'ignoreArticle', title: 'Ignore article', type: 'checkbox', defaultValue: true, description: t.gettext('Ignore terms such as "The" and "a" when sorting lists')}
+            {id: 'albumAtristsOnly', title: 'Album artists only', type: 'checkbox', defaultValue: true, description: t.gettext('When listing artists should we only see arttists with albums or all artists found. Warning: turning this off can impact performance with large libraries')}
           ]
         }
         {
           title: 'Advanced Options'
           id: 'advanced'
           children:[
-            {id: 'jsonRpcEndpoint', title: 'JsonRPC path', type: 'textfield', defaultValue: 'jsonrpc', description: "Default is 'jsonrpc'"}
-            {id: 'socketsHost', title: 'Websockets Host', type: 'textfield', defaultValue: 'auto', description: "The hostname used for websockets connection. Set to 'auto' to use the current hostname."}
-            {id: 'pollInterval', title: 'Poll Interval', type: 'select', defaultValue: '10000', options: {'5000': '5 sec', '10000': '10 sec', '30000': '30 sec', '60000': '1 min'}, description: "How often do I poll for updates from Kodi (Only applies when websockets inactive)"}
+            {id: 'socketsPort', title: 'Websockets port', type: 'textfield', defaultValue: '9090', description: t.gettext("Default is '9090'")}
+            {id: 'socketsHost', title: 'Websockets Host', type: 'textfield', defaultValue: 'auto', description: t.gettext("The hostname used for websockets connection. Set to 'auto' to use the current hostname.")}
+            {id: 'pollInterval', title: 'Poll Interval', type: 'select', defaultValue: '10000', options: {'5000': t.gettext('5 sec'), '10000': t.gettext('10 sec'), '30000': t.gettext('30 sec'), '60000': t.gettext('1 min')}, description: t.gettext("How often do I poll for updates from Kodi (Only applies when websockets inactive)")}
+            {id: 'reverseProxy', title: 'Reverse Proxy Support', type: 'checkbox', defaultValue: false, description: t.gettext('Enable support for reverse proxying.')}
           ]
         }
       ]

--- a/src/js/apps/state/kodi/notifications.js.coffee
+++ b/src/js/apps/state/kodi/notifications.js.coffee
@@ -3,15 +3,18 @@
   ## Deal with notifications from Kodi
   class StateApp.Notifications extends App.StateApp.Base
 
-    socketPort: config.get 'static', 'socketsPort'
-    socketPath: config.get 'static', 'jsonRpcEndpoint'
+    # Moved as the config is not returned only the defaults. Too early?
+    #socketPort: config.get 'static', 'socketsPort'
+    #socketPath: config.get 'static', 'jsonRpcEndpoint'
     wsActive: false
     wsObj: {}
 
     getConnection: ->
       host = config.get 'static', 'socketsHost'
+      socketPath = config.get 'static', 'jsonRpcEndpoint'
+      socketPort = config.get 'static', 'socketsPort'
       socketHost = if host is 'auto' then location.hostname else host
-      "ws://#{socketHost}:#{@socketPort}/#{@socketPath}?kodi"
+      "ws://#{socketHost}:#{socketPort}/#{socketPath}?kodi"
 
     initialize: ->
 
@@ -175,6 +178,3 @@
         else
           ## do nothing.
       return
-
-
-

--- a/src/js/entities/kodi/_base/collections.js.coffee
+++ b/src/js/entities/kodi/_base/collections.js.coffee
@@ -5,7 +5,7 @@
   class KodiEntities.Collection extends App.Entities.Collection
 
     ## Common jsonrpc settings.
-    url: config.get 'static', 'jsonRpcEndpoint'
+    url: -> helpers.url.baseKodiUrl "Collection"
     rpc: new Backbone.Rpc({
       useNamedParameters: true,
       namespaceDelimiter: ''

--- a/src/js/entities/kodi/_base/models.js.coffee
+++ b/src/js/entities/kodi/_base/models.js.coffee
@@ -1,7 +1,7 @@
 @Kodi.module "KodiEntities", (KodiEntities, App, Backbone, Marionette, $, _) ->
-	
+
 	class KodiEntities.Model extends App.Entities.Model
-    url: config.get 'static', 'jsonRpcEndpoint'
+    url: -> helpers.url.baseKodiUrl "Model"
     rpc: new Backbone.Rpc({
       useNamedParameters: true,
       namespaceDelimiter: ''

--- a/src/js/helpers/customMixins/kodi_entities.js.coffee
+++ b/src/js/helpers/customMixins/kodi_entities.js.coffee
@@ -20,7 +20,7 @@
 
 KodiMixins.Entities =
 
-  url: config.get 'static', 'jsonRpcEndpoint'
+  url: -> helpers.url.baseKodiUrl "Mixins"
   rpc: new Backbone.Rpc({
     useNamedParameters: true,
     namespaceDelimiter: ''
@@ -213,5 +213,3 @@ KodiMixins.Entities =
         req.push arg
     ## Set the method
     req
-
-

--- a/src/js/helpers/url.js.coffee
+++ b/src/js/helpers/url.js.coffee
@@ -15,6 +15,13 @@ helpers.url.map =
   file: 'browser/file/:id'
   playlist: 'playlist/:id'
 
+## Get base endpoint
+helpers.url.baseKodiUrl = (query = 'Kodi') ->
+  path = (config.get 'static', 'jsonRpcEndpoint') + "?" + query
+  if config.get 'static', 'reverseProxy'
+    path
+  else
+    "/" + path
 
 ## Get a url for a given model type.
 helpers.url.get = (type, id = '', replacements = {}) ->
@@ -115,4 +122,3 @@ helpers.url.parseTrailerUrl = (trailer) ->
     ret.img = "http://img.youtube.com/vi/#{ret.id}/0.jpg"
     ret.url = "https://www.youtube.com/watch?v=#{ret.id}"
   ret
-


### PR DESCRIPTION
This fixes the http://<kodi>/addons/<web interface> not working and hopefully adds support for reverse proxying. I don't use reverse proxy myself but I believe it should work.

I've not done anything for websockets as it's possible to enter the "host" and because they operate on a different port.

I've left the end point tags in as it's nice to see what is requesting what but I can remove them.

How does it look?