### PR TITLE
RFC: Translations

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,8 @@ module.exports = function (grunt) {
   // Js Dist files.
   var jsDistApp = jsDistFolder + 'app.js';
   var jsDistTpl = jsDistFolder + 'tpl.js';
+  
+  var srcLangs = 'resources/language/';
 
   // The order of concat files.
   function getConcatStack() {
@@ -85,6 +87,10 @@ module.exports = function (grunt) {
       coffee: {
         files: [jsSrcFolder + '{,**/}*.coffee'],
         tasks: ['coffee', 'concat', 'uglify:dev']
+      },
+      langs: {
+        files: [srcLangs + '**/*.po'],
+        tasks: ['execute']
       }
     },
 
@@ -215,6 +221,12 @@ module.exports = function (grunt) {
           }
         }]
       }
+    },
+    
+    execute: {
+        target: {
+            src  : ['convertTrans']
+        }
     }
   });
 
@@ -227,6 +239,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-browser-sync');
   grunt.loadNpmTasks('grunt-contrib-coffee');
   grunt.loadNpmTasks('grunt-eco');
+  grunt.loadNpmTasks('grunt-execute');
 
   /**
    * Tasks
@@ -237,6 +250,7 @@ module.exports = function (grunt) {
     'concat',
     'uglify:dist',
     'compass:dist',
+    'execute'
     //'jshint'
   ]);
 

--- a/convertTrans
+++ b/convertTrans
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+fs = require('fs');
+var po2json = require('po2json');
+var manifest = [];
+
+//Remove the current manifest.json file
+try {
+  fs.unlinkSync('dist/resources/language/manifest.json');
+} catch (e) {
+  console.log('Info: manifest.json not found for deletion');
+}
+
+var parsePO2JSON = function(file, callback) {
+  po2json.parseFile('resources/language/' + file + '/strings.po', { format: 'jed1.x' }, function (err, jsonData) {
+    if (!err) {
+      var lang = jsonData.locale_data.messages[''].lang;
+      fs.writeFile('dist/resources/language/'+lang+'.json', JSON.stringify(jsonData), function(err) {
+        if (err) {
+          console.log(err);
+          callback (false);
+        } else {
+          manifest.push({name: file, lang: lang, path: file});
+          callback (true);
+        }
+      });
+    } else {
+      console.log('Error reading file: ' + file + '/strings.po');
+      callback (false);
+    }
+  });
+}
+
+
+fs.readdir('resources/language/', function(err, dirs) {
+  var n = 0;
+  for (var i=0; i < dirs.length; i++) {
+    parsePO2JSON(dirs[i], function(cb) {
+      n++;
+      if (n === dirs.length) {
+        fs.writeFile('dist/resources/language/manifest.json', JSON.stringify(manifest), function(err) {
+          if (err) {
+            console.log(err);
+          } else {
+            console.log('manifest.json written');
+          }
+        });
+      }
+    });
+  }
+});

--- a/convertTrans
+++ b/convertTrans
@@ -1,15 +1,8 @@
 #!/usr/bin/env node
 
-fs = require('fs');
+var fs = require('fs');
 var po2json = require('po2json');
 var manifest = [];
-
-//Remove the current manifest.json file
-try {
-  fs.unlinkSync('dist/resources/language/manifest.json');
-} catch (e) {
-  console.log('Info: manifest.json not found for deletion');
-}
 
 var parsePO2JSON = function(file, callback) {
   po2json.parseFile('resources/language/' + file + '/strings.po', { format: 'jed1.x' }, function (err, jsonData) {

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -1,0 +1,314 @@
+# Kodi Media Center language file
+# Addon Name: Default Webinterface?
+# Addon id: webinterface.default?
+# Addon Provider: Team Kodi?
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: XBMC Translation Team\n"
+"Language-Team: English (http://www.transifex.com/projects/p/xbmc-addons/language/en/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt ""
+msgid "Nothing Playing"
+msgstr ""
+
+msgctxt ""
+msgid "Deselect All"
+msgstr ""
+
+msgctxt ""
+msgid "Filters"
+msgstr ""
+
+msgctxt ""
+msgid "Sort"
+msgstr ""
+
+msgctxt ""
+msgid "Select a filter"
+msgstr ""
+
+msgctxt ""
+msgid "Select an option"
+msgstr ""
+
+msgctxt ""
+msgid "filter"
+msgstr ""
+
+msgctxt ""
+msgid "Add Filter"
+msgstr ""
+
+msgid "Which player to start with"
+msgstr ""
+
+msgctxt ""
+msgid "Ignore terms such as "The" and "a" when sorting lists"
+msgstr ""
+
+msgctxt ""
+msgid "When listing artists should we only see artists with albums or all artists found. Warning: turning this off can impact performance with large libraries"
+msgstr ""
+
+msgctxt ""
+msgid "is the default"
+msgstr ""
+
+msgctxt ""
+msgid "The hostname used for websockets connection. Set to 'auto' to use the current hostname."
+msgstr ""
+
+msgctxt ""
+msgid "How often do I poll for updates from Kodi (Only applies when websockets inactive)"
+msgstr ""
+
+msgctxt ""
+msgid "Enable support for reverse proxying."
+msgstr ""
+
+msgctxt ""
+msgid "Web Settings saved."
+msgstr ""
+
+msgctxt ""
+msgid "Just a sec..."
+msgstr ""
+
+msgctxt ""
+msgid "Unable to communicate with Kodi in a long time. I think it's dead Jim!"
+msgstr ""
+
+msgctxt ""
+msgid "Video library scan started"
+msgstr ""
+
+msgctxt ""
+msgid "Video library scan complete"
+msgstr ""
+
+msgctxt ""
+msgid "Audio library scan started"
+msgstr ""
+
+msgctxt ""
+msgid "Audio library scan complete"
+msgstr ""
+
+msgctxt ""
+msgid "Kodi has quit"
+msgstr ""
+
+msgctxt ""
+msgid "Sections"
+msgstr ""
+
+msgctxt ""
+msgid "Back"
+msgstr ""
+
+msgctxt ""
+msgid "Loading folder..."
+msgstr ""
+
+msgctxt ""
+msgid "Show More"
+msgstr ""
+
+msgctxt ""
+msgid "to Kodi"
+msgstr ""
+
+msgctxt ""
+msgid "Playlist refreshed"
+msgstr ""
+
+msgctxt ""
+msgid "Kodi"
+msgstr ""
+
+msgctxt ""
+msgid "Local"
+msgstr ""
+
+msgctxt ""
+msgid "Playlists"
+msgstr ""
+
+msgctxt ""
+msgid "Existing playlists"
+msgstr ""
+
+msgctxt ""
+msgid "Empty Playlist, you should probably add something to it?"
+msgstr ""
+
+msgctxt ""
+msgid "Create a new list"
+msgstr ""
+
+msgctxt ""
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt ""
+msgid "Added to your playlist"
+msgstr ""
+
+msgctxt ""
+msgid "Give your playlist a name"
+msgstr ""
+
+msgctxt ""
+msgid "Recently Added"
+msgstr ""
+
+msgctxt ""
+msgid "Recently Played"
+msgstr ""
+
+msgctxt ""
+msgid "Season"
+msgstr ""
+
+msgctxt ""
+msgid "Episode"
+msgstr ""
+
+msgctxt ""
+msgid "Play"
+msgstr ""
+
+msgctxt ""
+msgid "Queue"
+msgstr ""
+
+msgctxt ""
+msgid "View on imdb"
+msgstr ""
+
+# Video and audio stream, such as 720, x264, AC3, etc.
+msgctxt ""
+msgid "Stream"
+msgstr ""
+
+msgctxt ""
+msgid "Download"
+msgstr ""
+
+msgctxt ""
+msgid "complete"
+msgstr ""
+
+msgctxt ""
+msgid "Synopsis"
+msgstr ""
+
+msgctxt ""
+msgid "Full Cast"
+msgstr ""
+
+msgctxt ""
+msgid "Websockets Closed"
+msgstr ""
+
+msgctxt ""
+msgid "Websockets Host"
+msgstr ""
+
+msgctxt ""
+msgid "Websockets Port"
+msgstr ""
+
+msgctxt ""
+msgid "Default player"
+msgstr ""
+
+msgctxt ""
+msgid "Ignore article"
+msgstr ""
+
+msgctxt ""
+msgid "Album artists only"
+msgstr ""
+
+msgctxt ""
+msgid "Poll Interval"
+msgstr ""
+
+msgctxt ""
+msgid "Reverse Proxy Support"
+msgstr ""
+
+msgctxt ""
+msgid "Language"
+msgstr ""
+
+msgctxt ""
+msgid "Preferred language"
+msgstr ""
+
+msgctxt ""
+msgid "Loading folder..."
+msgstr ""
+
+msgctxt ""
+msgid "Ignore articles (terms such as \"The\" and \"A\") when sorting lists"
+msgstr ""
+
+# Short for "second"
+msgctxt ""
+msgid "sec"
+msgstr ""
+
+msgctxt ""
+msgid "Your browser doesn't support websockets! Get with the times and update your browser."
+msgstr ""
+
+msgctxt ""
+msgid "Failed to connect to websockets"
+msgstr "Failed to connect to websockets, so I am falling back to polling for updates. Which makes things slower and uses more resources. Please ensure you have 'Allow programs on other systems to control Kodi' ENABLED in the Kodi settings (System > Services > Remote control). You may also get this if you are using proxies or accessing via an IP addess when localhost will suffice. If websockets normally works, you might just need to refresh your browser."
+
+msgctxt ""
+msgid "Video"
+msgstr ""
+
+msgctxt ""
+msgid "Audio"
+msgstr ""
+
+msgctxt ""
+msgid "Cast"
+msgstr ""
+
+msgctxt ""
+msgid "Director"
+msgid_plural "Directors"
+msgstr[0] ""
+msgstr[1] ""
+
+msgctxt ""
+msgid "Writer"
+msgid_plural "Writers"
+msgstr[0] ""
+msgstr[1] ""
+
+msgctxt ""
+msgid "Subtitle"
+msgid_plural "Subtitles"
+msgstr[0] ""
+msgstr[1] ""
+
+msgctxt ""
+msgid "Result"
+msgid_plural "Results"
+msgstr[0] ""
+msgstr[1] ""

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -1,0 +1,220 @@
+# Kodi Media Center language file
+# Addon Name: Default Webinterface?
+# Addon id: webinterface.default?
+# Addon Provider: Team Kodi?
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: XBMC Translation Team\n"
+"Language-Team: English (http://www.transifex.com/projects/p/xbmc-addons/language/en/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt ""
+msgid "Nothing playing"
+msgstr ""
+
+msgctxt ""
+msgid "Deselect All"
+msgstr ""
+
+msgctxt ""
+msgid "Filters"
+msgstr ""
+
+msgctxt ""
+msgid "Sort"
+msgstr ""
+
+msgctxt ""
+msgid "Select a filter"
+msgstr ""
+
+msgctxt ""
+msgid "Select an option"
+msgstr ""
+
+msgctxt ""
+msgid "filter"
+msgstr ""
+
+msgctxt ""
+msgid "Add Filter"
+msgstr ""
+
+msgctxt ""
+msgid "Which player to start with"
+msgstr ""
+
+msgctxt ""
+msgid "Ignore terms such as "The" and "a" when sorting lists"
+msgstr ""
+
+msgctxt ""
+msgid "When listing artists should we only see artists with albums or all artists found. Warning: turning this off can impact performance with large libraries"
+msgstr ""
+
+msgctxt ""
+msgid "Default is"
+msgstr ""
+
+msgctxt ""
+msgid "The hostname used for websockets connection. Set to 'auto' to use the current hostname."
+msgstr ""
+
+msgctxt ""
+msgid "How often do I poll for updates from Kodi (Only applies when websockets inactive"
+msgstr ""
+
+msgctxt ""
+msgid "Enable support for reverse proxying."
+msgstr ""
+
+msgctxt ""
+msgid "Web Settings saved."
+msgstr ""
+
+msgctxt ""
+msgid "Just a sec..."
+msgstr ""
+
+msgctxt ""
+msgid "Unable to communicate with Kodi in a long time. I think it's dead Jim!"
+msgstr ""
+
+msgctxt ""
+msgid "Video library scan started"
+msgstr ""
+
+msgctxt ""
+msgid "Video library scan complete"
+msgstr ""
+
+msgctxt ""
+msgid "Audio library scan started"
+msgstr ""
+
+msgctxt ""
+msgid "Audio library scan complete"
+msgstr ""
+
+msgctxt ""
+msgid "Kodi has quit"
+msgstr ""
+
+msgctxt ""
+msgid "Back"
+msgstr ""
+
+msgctxt ""
+msgid "Loading folder..."
+msgstr ""
+
+msgctxt ""
+msgid "Show More"
+msgstr ""
+
+msgctxt ""
+msgid "to Kodi"
+msgstr ""
+
+msgctxt ""
+msgid "Playlist refreshed"
+msgstr ""
+
+msgctxt ""
+msgid "Kodi"
+msgstr ""
+
+msgctxt ""
+msgid "Local"
+msgstr ""
+
+msgctxt ""
+msgid "Playlists"
+msgstr ""
+
+msgctxt ""
+msgid "Existing playlists"
+msgstr ""
+
+msgctxt ""
+msgid "Empty Playlist, you should probably add something to it?"
+msgstr ""
+
+msgctxt ""
+msgid "Create a new list"
+msgstr ""
+
+msgctxt ""
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt ""
+msgid "Added to your playlist"
+msgstr ""
+
+msgctxt ""
+msgid "Give your playlist a name"
+msgstr ""
+
+msgctxt ""
+msgid "Season"
+msgstr ""
+
+msgctxt ""
+msgid "Episode"
+msgstr ""
+
+msgctxt ""
+msgid "Play"
+msgstr ""
+
+msgctxt ""
+msgid "Queue"
+msgstr ""
+
+# Video and audio stream, such as 720, x264, AC3, etc.
+msgctxt ""
+msgid "Stream"
+msgstr ""
+
+msgctxt ""
+msgid "Download"
+msgstr ""
+
+msgctxt ""
+msgid "complete"
+msgstr ""
+
+msgctxt ""
+msgid "Synopsis"
+msgstr ""
+
+msgctxt ""
+msgid "Full Cast"
+msgstr ""
+
+msgctxt ""
+msgid "Websockets Closed"
+msgstr ""
+
+msgctxt ""
+msgid "Your browser doesn't support websockets! Get with the times and update your browser."
+msgstr ""
+
+msgctxt ""
+msgid "Failed to connect to websockets, so I am falling back to polling for updates. Which makes things slower and uses more resources. Please ensure you have 'Allow programs on other systems to control Kodi' ENABLED in the Kodi settings (System > Services > Remote control). You may also get this if you are using proxies or accessing via an IP addess when localhost will suffice. If websockets normally works, you might just need to refresh your browser."
+msgstr ""
+
+msgctxt ""
+msgid "Result"
+msgid_plural "Results"
+msgstr[0] ""
+msgstr[1] ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -1,0 +1,220 @@
+# Kodi Media Center language file
+# Addon Name: Default Webinterface?
+# Addon id: webinterface.default?
+# Addon Provider: Team Kodi?
+msgid ""
+msgstr ""
+"Project-Id-Version: XBMC Addons\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: XBMC Translation Team\n"
+"Language-Team: English (http://www.transifex.com/projects/p/xbmc-addons/language/en/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: gr\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt ""
+msgid "Nothing playing"
+msgstr ""
+
+msgctxt ""
+msgid "Deselect All"
+msgstr ""
+
+msgctxt ""
+msgid "Filters"
+msgstr ""
+
+msgctxt ""
+msgid "Sort"
+msgstr ""
+
+msgctxt ""
+msgid "Select a filter"
+msgstr ""
+
+msgctxt ""
+msgid "Select an option"
+msgstr ""
+
+msgctxt ""
+msgid "filter"
+msgstr ""
+
+msgctxt ""
+msgid "Add Filter"
+msgstr ""
+
+msgctxt ""
+msgid "Which player to start with"
+msgstr ""
+
+msgctxt ""
+msgid "Ignore terms such as "The" and "a" when sorting lists"
+msgstr ""
+
+msgctxt ""
+msgid "When listing artists should we only see artists with albums or all artists found. Warning: turning this off can impact performance with large libraries"
+msgstr ""
+
+msgctxt ""
+msgid "Default is"
+msgstr ""
+
+msgctxt ""
+msgid "The hostname used for websockets connection. Set to 'auto' to use the current hostname."
+msgstr ""
+
+msgctxt ""
+msgid "How often do I poll for updates from Kodi (Only applies when websockets inactive"
+msgstr ""
+
+msgctxt ""
+msgid "Enable support for reverse proxying."
+msgstr ""
+
+msgctxt ""
+msgid "Web Settings saved."
+msgstr ""
+
+msgctxt ""
+msgid "Just a sec..."
+msgstr ""
+
+msgctxt ""
+msgid "Unable to communicate with Kodi in a long time. I think it's dead Jim!"
+msgstr ""
+
+msgctxt ""
+msgid "Video library scan started"
+msgstr ""
+
+msgctxt ""
+msgid "Video library scan complete"
+msgstr ""
+
+msgctxt ""
+msgid "Audio library scan started"
+msgstr ""
+
+msgctxt ""
+msgid "Audio library scan complete"
+msgstr ""
+
+msgctxt ""
+msgid "Kodi has quit"
+msgstr ""
+
+msgctxt ""
+msgid "Back"
+msgstr ""
+
+msgctxt ""
+msgid "Loading folder..."
+msgstr ""
+
+msgctxt ""
+msgid "Show More"
+msgstr ""
+
+msgctxt ""
+msgid "to Kodi"
+msgstr ""
+
+msgctxt ""
+msgid "Playlist refreshed"
+msgstr ""
+
+msgctxt ""
+msgid "Kodi"
+msgstr ""
+
+msgctxt ""
+msgid "Local"
+msgstr ""
+
+msgctxt ""
+msgid "Playlists"
+msgstr ""
+
+msgctxt ""
+msgid "Existing playlists"
+msgstr ""
+
+msgctxt ""
+msgid "Empty Playlist, you should probably add something to it?"
+msgstr ""
+
+msgctxt ""
+msgid "Create a new list"
+msgstr ""
+
+msgctxt ""
+msgid "Add to playlist"
+msgstr ""
+
+msgctxt ""
+msgid "Added to your playlist"
+msgstr ""
+
+msgctxt ""
+msgid "Give your playlist a name"
+msgstr ""
+
+msgctxt ""
+msgid "Season"
+msgstr ""
+
+msgctxt ""
+msgid "Episode"
+msgstr ""
+
+msgctxt ""
+msgid "Play"
+msgstr ""
+
+msgctxt ""
+msgid "Queue"
+msgstr ""
+
+# Video and audio stream, such as 720, x264, AC3, etc.
+msgctxt ""
+msgid "Stream"
+msgstr ""
+
+msgctxt ""
+msgid "Download"
+msgstr ""
+
+msgctxt ""
+msgid "complete"
+msgstr ""
+
+msgctxt ""
+msgid "Synopsis"
+msgstr ""
+
+msgctxt ""
+msgid "Full Cast"
+msgstr ""
+
+msgctxt ""
+msgid "Websockets Closed"
+msgstr ""
+
+msgctxt ""
+msgid "Your browser doesn't support websockets! Get with the times and update your browser."
+msgstr ""
+
+msgctxt ""
+msgid "Failed to connect to websockets, so I am falling back to polling for updates. Which makes things slower and uses more resources. Please ensure you have 'Allow programs on other systems to control Kodi' ENABLED in the Kodi settings (System > Services > Remote control). You may also get this if you are using proxies or accessing via an IP addess when localhost will suffice. If websockets normally works, you might just need to refresh your browser."
+msgstr ""
+
+msgctxt ""
+msgid "Result"
+msgid_plural "Results"
+msgstr[0] ""
+msgstr[1] ""

--- a/src/js/app.coffee
+++ b/src/js/app.coffee
@@ -37,9 +37,20 @@
   App
 
 $(document).ready =>
-  $.getJSON("resources/language/" + config.static.lang + ".json", (data) -> 
+  # Initialise language support
+  $.getJSON("resources/language/" + config.static.lang + ".json", (data) ->
     window.t = new Jed(data)
-    t.options["missing_key_callback"] = (key) -> console.error key
+    t.options["missing_key_callback"] = (key) -> console.warn key
     Kodi.start()
+  ).error( ->
+    # No file for language?!
+    # Revert to en.json and assume it will always be there.
+    $.getJSON("resources/language/en.json", (data) ->
+      window.t = new Jed(data)
+      t.options["missing_key_callback"] = (key) -> console.warn key
+      Kodi.start()
+    ).error(
+      alert 'Language file not found! Check your installation and/or reinstall.'
+    )
   )
   $.material.init()

--- a/src/js/app.coffee
+++ b/src/js/app.coffee
@@ -16,6 +16,7 @@
     searchIndexCacheExpiry: (24 * 60 * 60) # 1 day
     collectionCacheExpiry: (7 * 24 * 60 * 60) # 1 week (gets wiped on library update)
     addOnsLoaded: false
+    lang: (if JSON.parse(localStorage.getItem('config:app-config:local')).data.lang? then JSON.parse(localStorage.getItem('config:app-config:local')).data.lang else 'en')
 }
 
 ## The App Inance
@@ -36,5 +37,9 @@
   App
 
 $(document).ready =>
-  @Kodi.start()
+  $.getJSON("resources/language/" + config.static.lang + ".json", (data) -> 
+    window.t = new Jed(data)
+    t.options["missing_key_callback"] = (key) -> console.error key
+    Kodi.start()
+  )
   $.material.init()

--- a/src/js/app.coffee
+++ b/src/js/app.coffee
@@ -16,7 +16,7 @@
     searchIndexCacheExpiry: (24 * 60 * 60) # 1 day
     collectionCacheExpiry: (7 * 24 * 60 * 60) # 1 week (gets wiped on library update)
     addOnsLoaded: false
-    lang: (if JSON.parse(localStorage.getItem('config:app-config:local')).data.lang? then JSON.parse(localStorage.getItem('config:app-config:local')).data.lang else 'en')
+    lang: (JSON.parse(localStorage.getItem('config:app-config:local')).data.lang || 'en')
 }
 
 ## The App Inance

--- a/src/js/apps/album/landing/tpl/landing.jst.eco
+++ b/src/js/apps/album/landing/tpl/landing.jst.eco
@@ -1,4 +1,4 @@
-<h3>Recently Added</h3>
+<h3><%= t.gettext("Recently Added") %></h3>
 <div class="landing-section region-recently-added"></div>
-<h3>Recently Played</h3>
+<h3><%= t.gettext("Recently Played") %></h3>
 <div class="landing-section region-recently-played"></div>

--- a/src/js/apps/movie/landing/tpl/landing.jst.eco
+++ b/src/js/apps/movie/landing/tpl/landing.jst.eco
@@ -1,2 +1,2 @@
-<h3>Recently Added</h3>
+<h3><%= t.gettext("Recently Added") %></h3>
 <div class="landing-section region-recently-added"></div>

--- a/src/js/apps/movie/show/tpl/details_meta.jst.eco
+++ b/src/js/apps/movie/show/tpl/details_meta.jst.eco
@@ -25,22 +25,22 @@
 
     <ul class="people">
         <% if @director.length > 0: %>
-            <li><label>Director:</label> <span><%- helpers.url.filterLinks 'movies', 'director', @director %></span></li>
+            <li><label><%= t.ngettext("Director", "Directors", @director.length) %>:</label> <span><%- helpers.url.filterLinks 'movies', 'director', @director %></span></li>
         <% end %>
         <% if @writer.length > 0: %>
-            <li><label>Writer:</label> <span><%- helpers.url.filterLinks 'movies', 'writer', @writer %></span></li>
+            <li><label><%= t.ngettext("Writer", "Writers", @writer.length) %>:</label> <span><%- helpers.url.filterLinks 'movies', 'writer', @writer %></span></li>
         <% end %>
         <% if @cast.length > 0: %>
-            <li><label>Cast:</label> <span><%- helpers.url.filterLinks 'movies', 'cast', _.pluck(@cast, 'name') %></span></li>
+            <li><label><%= t.gettext("Cast") %>:</label> <span><%- helpers.url.filterLinks 'movies', 'cast', _.pluck(@cast, 'name') %></span></li>
         <% end %>
     </ul>
 
     <ul class="streams">
-        <li><label>Video:</label> <span><%= _.pluck( @streamdetails.video, 'label' ).join(', ') %></span></li>
-        <li><label>Audio:</label> <span><%= _.pluck( @streamdetails.audio, 'label' ).join(', ') %></span></li>
+        <li><label><%= t.gettext("Video") %>:</label> <span><%= _.pluck( @streamdetails.video, 'label' ).join(', ') %></span></li>
+        <li><label><%= t.gettext("Audio") %>:</label> <span><%= _.pluck( @streamdetails.audio, 'label' ).join(', ') %></span></li>
         <% if @streamdetails.subtitle.length > 0 and @streamdetails.subtitle[0].label isnt '': %>
-            <li><label>Subtitle:</label>
-                <span class="dropdown"><span data-toggle="dropdown"><%= _.first _.pluck( @streamdetails.subtitle, 'label' ) %></span>
+            <li><label><%= t.ngettext("Subtitle", "Subtitles", @streamdetails.subtitle.length) %>:</label>
+                <span class="dropdown"><span data-toggle="dropdown"><%= _.pluck( @streamdetails.subtitle, 'label' ).join(', ') %></span>
                 <ul class="dropdown-menu">
                     <% for sub in @streamdetails.subtitle: %>
                         <li><%= sub.label %></li>

--- a/src/js/apps/navMain/show/tpl/nav_sub.jst.eco
+++ b/src/js/apps/navMain/show/tpl/nav_sub.jst.eco
@@ -1,2 +1,2 @@
-<h3><%= t.gettext(@title) %></h3>
+<h3><%= @title %></h3>
 <ul class="items"></ul>

--- a/src/js/apps/playlist/list/tpl/playlist_bar.jst.eco
+++ b/src/js/apps/playlist/list/tpl/playlist_bar.jst.eco
@@ -6,12 +6,12 @@
     <div class="playlist-menu dropdown">
         <i data-toggle="dropdown" class="menu-toggle"></i>
         <ul class="dropdown-menu pull-right">
-            <li class="dropdown-header">Current Playlist</li>
-            <li><a href="#" class="clear-playlist">Clear Playlist</a></li>
-            <li><a href="#" class="refresh-playlist">Refresh Playlist</a></li>
-            <li class="dropdown-header">Kodi</li>
-            <li><a href="#" class="party-mode">Party Mode <i class="mdi-navigation-check"></i></a></li>
-            <li><a href="#" class="save-playlist">Save Kodi Playlist</a></li>
+            <li class="dropdown-header"><%= t.gettext('Current Playlist') %></li>
+            <li><a href="#" class="clear-playlist"><%= t.gettext('Clear Playlist') %></a></li>
+            <li><a href="#" class="refresh-playlist"><%= t.gettext('Refresh Playlist') %></a></li>
+            <li class="dropdown-header"><%= t.gettext('Kodi') %></li>
+            <li><a href="#" class="party-mode"><%= t.gettext('Party Mode') %> <i class="mdi-navigation-check"></i></a></li>
+            <li><a href="#" class="save-playlist"><%= t.gettext('Save Kodi Playlist') %></a></li>
             </li>
         </ul>
     </div>
@@ -19,8 +19,8 @@
 <div class="playlists-wrapper">
     <div class="kodi-playlists">
         <ul class="media-toggle">
-            <li class="audio">Audio</li>
-            <li class="video">Video</li>
+            <li class="audio"><%= t.gettext('Audio') %></li>
+            <li class="video"><%= t.gettext('Video') %></li>
         </ul>
         <div class="kodi-playlist"></div>
     </div>

--- a/src/js/apps/settings/show/local/local_controller.js.coffee
+++ b/src/js/apps/settings/show/local/local_controller.js.coffee
@@ -42,7 +42,6 @@
       @layout.regionContent.show form
 
     getStructure: ->
-      console.log availableLangs
       [
         {
           title: 'General Options'

--- a/src/js/apps/settings/show/local/local_controller.js.coffee
+++ b/src/js/apps/settings/show/local/local_controller.js.coffee
@@ -2,16 +2,25 @@
 
   class Local.Controller extends App.Controllers.Base
 
+    availableLangs = {}
+
     initialize: ->
 
       ## Get and setup the layout
+      
       @layout = @getLayoutView()
       @listenTo @layout, "show", =>
         @getSubNav()
-        @getForm()
+        @getLangs()
 
       ## Render the layout
       App.regionContent.show @layout
+
+    gotLangs: (langs) =>
+      availableLangs = langs
+      @getForm()
+
+    getLangs: -> helpers.translate.getLanguages(@gotLangs)
 
     getLayoutView: ->
       new App.SettingsApp.Show.Layout()
@@ -33,12 +42,13 @@
       @layout.regionContent.show form
 
     getStructure: ->
+      console.log availableLangs
       [
         {
           title: 'General Options'
           id: 'general'
           children:[
-            {id: 'lang', title: t.gettext("Language"), type: 'select', options: { en: "English", fr: "French", gr: "German" }, defaultValue: 'en', description: t.gettext('Preferred language')}
+            {id: 'lang', title: t.gettext("Language"), type: 'select', options: availableLangs, defaultValue: 'en', description: t.gettext('Preferred language')}
             {id: 'defaultPlayer', title: t.gettext("Default player"), type: 'select', options: {auto: 'Auto', kodi: 'Kodi', local: 'Local'}, defaultValue: 'auto', description: t.gettext('Which player to start with')}
           ]
         }

--- a/src/js/apps/settings/show/local/local_controller.js.coffee
+++ b/src/js/apps/settings/show/local/local_controller.js.coffee
@@ -38,25 +38,26 @@
           title: 'General Options'
           id: 'general'
           children:[
-            {id: 'defaultPlayer', title: 'Default player', type: 'select', options: {auto: 'Auto', kodi: 'Kodi', local: 'Local'}, defaultValue: 'auto', description: t.gettext('What player to start with')}
+            {id: 'lang', title: t.gettext("Language"), type: 'select', options: { en: "English", fr: "French", gr: "German" }, defaultValue: 'en', description: t.gettext('Preferred language')}
+            {id: 'defaultPlayer', title: t.gettext("Default player"), type: 'select', options: {auto: 'Auto', kodi: 'Kodi', local: 'Local'}, defaultValue: 'auto', description: t.gettext('Which player to start with')}
           ]
         }
         {
           title: 'List options'
           id: 'list'
           children:[
-            {id: 'ignoreArticle', title: 'Ignore article', type: 'checkbox', defaultValue: true, description: t.gettext('Ignore terms such as "The" and "a" when sorting lists')}
-            {id: 'albumAtristsOnly', title: 'Album artists only', type: 'checkbox', defaultValue: true, description: t.gettext('When listing artists should we only see arttists with albums or all artists found. Warning: turning this off can impact performance with large libraries')}
+            {id: 'ignoreArticle', title: t.gettext("Ignore article"), type: 'checkbox', defaultValue: true, description: t.gettext('Ignore articles (terms such as "The" and "A") when sorting lists')}
+            {id: 'albumAtristsOnly', title: t.gettext("Album artists only"), type: 'checkbox', defaultValue: true, description: t.gettext('When listing artists should we only see artists with albums or all artists found. Warning: turning this off can impact performance with large libraries')}
           ]
         }
         {
           title: 'Advanced Options'
           id: 'advanced'
           children:[
-            {id: 'socketsPort', title: 'Websockets port', type: 'textfield', defaultValue: '9090', description: t.gettext("Default is '9090'")}
-            {id: 'socketsHost', title: 'Websockets Host', type: 'textfield', defaultValue: 'auto', description: t.gettext("The hostname used for websockets connection. Set to 'auto' to use the current hostname.")}
-            {id: 'pollInterval', title: 'Poll Interval', type: 'select', defaultValue: '10000', options: {'5000': t.gettext('5 sec'), '10000': t.gettext('10 sec'), '30000': t.gettext('30 sec'), '60000': t.gettext('1 min')}, description: t.gettext("How often do I poll for updates from Kodi (Only applies when websockets inactive)")}
-            {id: 'reverseProxy', title: 'Reverse Proxy Support', type: 'checkbox', defaultValue: false, description: t.gettext('Enable support for reverse proxying.')}
+            {id: 'socketsPort', title: t.gettext("Websockets Port"), type: 'textfield', defaultValue: '9090', description: "9090 " + t.gettext("is the default")}
+            {id: 'socketsHost', title: t.gettext("Websockets Host"), type: 'textfield', defaultValue: 'auto', description: t.gettext("The hostname used for websockets connection. Set to 'auto' to use the current hostname.")}
+            {id: 'pollInterval', title: t.gettext("Poll Interval"), type: 'select', defaultValue: '10000', options: {'5000': "5 " + t.gettext('sec'), '10000': "10 " + t.gettext('sec'), '30000': "30 " + t.gettext('sec'), '60000': "60 " + t.gettext('sec')}, description: t.gettext("How often do I poll for updates from Kodi (Only applies when websockets inactive)")}
+            {id: 'reverseProxy', title: t.gettext("Reverse Proxy Support"), type: 'checkbox', defaultValue: false, description: t.gettext('Enable support for reverse proxying.')}
           ]
         }
       ]

--- a/src/js/apps/shell/show/tpl/shell.jst.eco
+++ b/src/js/apps/shell/show/tpl/shell.jst.eco
@@ -22,7 +22,7 @@
 
         <div id="sidebar-one"></div>
 
-        <div id="content">Loading things...</div>
+        <div id="content"><%= t.gettext("Loading things...") %></div>
 
     </div>
 
@@ -41,9 +41,9 @@
 
     <div class="player-menu-wrapper">
         <ul class="player-menu">
-            <li class="video-scan">Scan Video Library</li>
-            <li class="audio-scan">Scan Audio Library</li>
-            <li class="about">About Chorus</li>
+            <li class="video-scan"><%= t.gettext("Scan Video Library") %></li>
+            <li class="audio-scan"><%= t.gettext("Scan Audio Library") %></li>
+            <li class="about"><%= t.gettext("About Chorus") %></li>
         </ul>
     </div>
 

--- a/src/js/apps/state/kodi/notifications.js.coffee
+++ b/src/js/apps/state/kodi/notifications.js.coffee
@@ -62,11 +62,7 @@
       console.log data
 
     socketConnectionErrorMsg: ->
-      msg = "Failed to connect to websockets, so I am falling back to polling for updates. Which makes things slower and " +
-        "uses more resources. Please ensure you have 'Allow programs on other systems to control Kodi' ENABLED " +
-        "in the Kodi settings (System > Services > Remote control).  You may also get this if you are using proxies or " +
-        "accessing via an IP addess when localhost will suffice. If websockets normally works, you might just need to " +
-        "refresh your browser."
+      msg = "Failed to connect to websockets"
       t.gettext msg
 
     ## Force a state refresh
@@ -156,6 +152,7 @@
           wait = 60
           # We set a timeout for {wait} seconds for a fallback for no input
           # this is to prevent an open dialog preventing api requests
+          # Instead of encouraging entering random shizzle how about it's just cancelled and a message saying why?
           App.inputTimeout = setTimeout((->
             msg = wait + t.gettext(' seconds ago, an input dialog opened on xbmc and it is still open! To prevent ' +
               'a mainframe implosion, you should probably give me some text. I don\'t really care what it is at this point, ' +

--- a/src/js/apps/tvshow/episode/tpl/details_meta.jst.eco
+++ b/src/js/apps/tvshow/episode/tpl/details_meta.jst.eco
@@ -18,21 +18,21 @@
 
     <ul class="people">
         <% if @director.length > 0: %>
-            <li><label>Director:</label> <span><%- helpers.url.filterLinks 'tvshows', 'director', @director %></span></li>
+            <li><label><%= t.ngettext("Director", "Directors", @director.length) %>:</label> <span><%- helpers.url.filterLinks 'tvshows', 'director', @director %></span></li>
         <% end %>
         <% if @writer.length > 0: %>
-            <li><label>Writer:</label> <span><%- helpers.url.filterLinks 'tvshows', 'writer', @writer %></span></li>
+            <li><label><%= t.ngettext("Writer", "Writers", @writer.length) %>:</label> <span><%- helpers.url.filterLinks 'tvshows', 'writer', @writer %></span></li>
         <% end %>
         <% if @cast.length > 0: %>
-            <li><label>Cast:</label> <span><%- helpers.url.filterLinks 'tvshows', 'cast', _.pluck(@cast, 'name') %></span></li>
+            <li><label><%= t.gettext('Cast') %>:</label> <span><%- helpers.url.filterLinks 'tvshows', 'cast', _.pluck(@cast, 'name') %></span></li>
         <% end %>
     </ul>
 
     <ul class="streams">
-        <li><label>Video:</label> <span><%= _.pluck( @streamdetails.video, 'label' ).join(', ') %></span></li>
-        <li><label>Audio:</label> <span><%= _.pluck( @streamdetails.audio, 'label' ).join(', ') %></span></li>
+        <li><label><%= t.gettext('Video') %>:</label> <span><%= _.pluck( @streamdetails.video, 'label' ).join(', ') %></span></li>
+        <li><label><%= t.gettext('Audio') %>:</label> <span><%= _.pluck( @streamdetails.audio, 'label' ).join(', ') %></span></li>
         <% if @streamdetails.subtitle.length > 0 and @streamdetails.subtitle[0].label isnt '': %>
-            <li><label>Subtitle:</label>
+            <li><label><%= t.ngettext("Subtitle", "Subtitles", @streamdetails.subtitle.length) %>:</label>
                 <span class="dropdown"><span data-toggle="dropdown"><%= _.first _.pluck( @streamdetails.subtitle, 'label' ) %></span>
                 <ul class="dropdown-menu">
                     <% for sub in @streamdetails.subtitle: %>

--- a/src/js/apps/tvshow/landing/tpl/landing.jst.eco
+++ b/src/js/apps/tvshow/landing/tpl/landing.jst.eco
@@ -1,2 +1,2 @@
-<h3>Recently Added</h3>
+<h3><%= t.gettext("Recently Added") %></h3>
 <div class="landing-section region-recently-added"></div> 

--- a/src/js/apps/tvshow/season/tpl/details_meta.jst.eco
+++ b/src/js/apps/tvshow/season/tpl/details_meta.jst.eco
@@ -21,7 +21,7 @@
 
     <ul class="people">
         <% if @cast.length > 0: %>
-        <li><label>Cast:</label> <span><%- helpers.url.filterLinks 'tvshows', 'cast', _.pluck(@cast, 'name') %></span></li>
+        <li><label><%= t.gettext("Cast") %>:</label> <span><%- helpers.url.filterLinks 'tvshows', 'cast', _.pluck(@cast, 'name') %></span></li>
         <% end %>
     </ul>
 

--- a/src/js/apps/tvshow/show/tpl/details_meta.jst.eco
+++ b/src/js/apps/tvshow/show/tpl/details_meta.jst.eco
@@ -18,7 +18,7 @@
 
     <ul class="people">
         <% if @cast.length > 0: %>
-        <li><label>Cast:</label> <span><%- helpers.url.filterLinks 'tvshows', 'cast', _.pluck(@cast, 'name') %></span></li>
+        <li><label><%= t.gettext("Cast") %>:</label> <span><%- helpers.url.filterLinks 'tvshows', 'cast', _.pluck(@cast, 'name') %></span></li>
         <% end %>
     </ul>
 

--- a/src/js/components/form/tpl/form_item.jst.eco
+++ b/src/js/components/form/tpl/form_item.jst.eco
@@ -1,5 +1,5 @@
 <% if @title: %>
-    <label class="control-label"><%= t.gettext(@title) %></label>
+    <label class="control-label"><%= @title %></label>
 <% end %>
 <div class="element">
     <% if @type isnt 'checkbox': %>
@@ -10,6 +10,6 @@
         </div>
     <% end %>
     <% if @description: %>
-        <div class="help-block description"><%= t.gettext(@description) %></div>
+        <div class="help-block description"><%= @description %></div>
     <% end %>
 </div>

--- a/src/js/helpers/translate.js.coffee
+++ b/src/js/helpers/translate.js.coffee
@@ -2,16 +2,11 @@
   For everything translatable.
 ###
 
-## @TODO: Add translation data when I have some.
-jedOptions =
-  locale_data:
-    messages:
-      "":
-        domain: "messages"
-        lang: "en"
-        "plural_forms": "nplurals=2; plural=(n != 1);"
-    domain: "messages"
+helpers.translate = {}
 
-## t is our wrapper for all translate calls.
-t = new Jed(jedOptions)
-
+helpers.translate.getLanguages = (callback) ->
+  returnVal = ''
+  $.getJSON 'resources/language/manifest.json', (data) ->
+    _.each data, (lang) ->
+      returnVal += lang.lang + ': "' + lang.name + '", '
+    callback returnVal

--- a/src/js/helpers/translate.js.coffee
+++ b/src/js/helpers/translate.js.coffee
@@ -8,5 +8,11 @@ helpers.translate.getLanguages = (callback) ->
   returnVal = ''
   $.getJSON 'resources/language/manifest.json', (data) ->
     _.each data, (lang) ->
-      returnVal += lang.lang + ': "' + lang.name + '", '
-    callback returnVal
+      returnVal += '"' + lang.lang + '": "' + lang.name + '",'
+    callback JSON.parse '{' + (returnVal.slice 0, -1) + '}'
+
+helpers.translate.init = (callback) ->
+  $.getJSON("resources/language/" + config.static.lang + ".json", (data) -> 
+    window.t = new Jed(data)
+    t.options["missing_key_callback"] = (key) -> console.error key
+  )


### PR DESCRIPTION
This is mostly it I hope, a few things:

before:start doesn't seem work (as I expected) which is why Jed is started where it is and config.get can't be used.

The other problem I've gone around in circles with is getting the languages from the manifest file into the settings page. It needs to be via a callback but I'm not sure on where/how.

You'll need the po2json npm and then run the "convertTrans" to generate the files. The French and German are just for display purposes.

How's it looking?