### PR TITLE
fix addon.xml dependencies

### DIFF
--- a/dist/addon.xml
+++ b/dist/addon.xml
@@ -5,7 +5,6 @@
   name="Kodi Web Interface"
   provider-name="jez500">
   <requires>
-    <import addon="xbmc.gui" version="4.0.0"/>
     <import addon="xbmc.json" version="6.0.0" />
   </requires>
   <extension point="xbmc.gui.webinterface"/>


### PR DESCRIPTION
Do not depend on xbmc.gui.

Its unnecessary tbh and not a good idea see https://github.com/jez500/chorus2/issues/25