### PR TITLE
[FIX] web interface defaults to none in Services > Settings > Webserver

### DIFF
--- a/dist/addon.xml
+++ b/dist/addon.xml
@@ -7,8 +7,8 @@
   <requires>
     <import addon="xbmc.json" version="6.0.0" />
   </requires>
-  <extension point="xbmc.gui.webinterface"/>
   <extension point="xbmc.webinterface"/>
+  <extension point="xbmc.gui.webinterface"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">Chorus2</summary>
     <description lang="en">Control Kodi using your web browser</description>


### PR DESCRIPTION
What happens currently and many people have reported now in forums and I had noticed and fixed locally is, when trying to select the Chrous2 as the web interface in Services > Settings > Web interface it keeps defaulting to none and sometimes it stick and sometimes it goes back to none.

I suspect that this is because the compatibility to v14 ABI ```<extension point="xbmc.gui.webinterface"/>```  is at the top its being read first and the newer extension point isnt being evaluated properly.

That could probably be a bug in Kodi itself, but a good solution that worked for me was changing the order so new extension compatibility is present ontop.

I been carrying this change on my local addon.xml and it all works with no glitches. However I only tested with v15.X and V16.