### PR TITLE
fix grunt 'uglify' when using node v0.12

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -207,7 +207,7 @@ module.exports = function (grunt) {
       dist: {
         options: {
           mangle: true,
-          compress: true,
+          compress: {},
           banner: '/*! <%= pkg.name %> by Jeremy Graham - built on <%= grunt.template.today("dd-mm-yyyy") %> */\n'
         },
         files: [{


### PR DESCRIPTION
I just checked out this project to compare it to version chorus 1 and noticed that the gruntfile does not work the way it is defined when using node v0.12.

```
Running "uglify:dist" (uglify) task
[TypeError: Cannot assign to read only property 'warnings' of true]
>> Uglifying source "dist/js/app.js,dist/js/kodi-webinterface.js,dist/js/tpl.js" failed.
```

See https://github.com/gruntjs/grunt-contrib-uglify/issues/298 for details and solution.

What's the desired node version for this project?

Thanks.