### PR TITLE
Fix focusing on text input

### DIFF
--- a/src/js/apps/ui/ui_app.js.coffee
+++ b/src/js/apps/ui/ui_app.js.coffee
@@ -81,7 +81,10 @@
     $msg = $('<p>').html(msg)
     API.defaultButtons -> callback $('#text-input').val()
     API.openModal(title, $msg, callback, open)
-    App.getRegion('regionModalBody').$el.append($input.wrap('<div class="form-control-wrapper"></div>')).find('input').first().focus()
+    el = App.getRegion('regionModalBody').$el.append($input.wrap('<div class="form-control-wrapper"></div>'))
+    setTimeout ->
+      el.find('input').first().focus()
+    , 200
     $.material.init()
 
   App.commands.setHandler "ui:modal:close", ->


### PR DESCRIPTION
Focusing on the text input field didn't work for me. I think it happens because the visibility of the field is not set immediately probably due to material effect animation. Adding 200 ms timeout before focus() did the trick.